### PR TITLE
Fix: Stale document title on client-side navigation

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -17,7 +17,26 @@
     }
     lastY = y;
   }
+
+  $: pathname = $page.url.pathname;
+
+  $: normalizedPath =
+    pathname.length > 1 && pathname.endsWith('/')
+      ? pathname.slice(0, -1)
+      : pathname;
+
+  $: title =
+    normalizedPath === '/' ? 'Home' :
+    normalizedPath === '/cv' ? 'CV' :
+    normalizedPath === '/academia' ? 'Academic CV' :
+    normalizedPath === '/projects' ? 'Projects' :
+    normalizedPath === '/blog' ? 'Blog' :
+    'Niccolò Barbini';
 </script>
+
+<svelte:head>
+  <title>{title}</title>
+</svelte:head>
 
 <svelte:window bind:scrollY={y} />
 
@@ -28,7 +47,6 @@
 
 <div class="min-h-screen flex flex-col relative transition-colors duration-300">
   
-  <!-- Premium Glass Navbar -->
   <div 
     class="fixed top-6 left-0 right-0 z-50 flex justify-center transition-transform duration-500 cubic-bezier(0.22, 1, 0.36, 1)"
     class:-translate-y-32={isHidden}
@@ -36,10 +54,10 @@
     <div class="navbar w-auto px-8 py-3 rounded-full bg-white/40 dark:bg-black/40 backdrop-blur-2xl border border-white/40 dark:border-white/10 shadow-[0_8px_32px_0_rgba(31,38,135,0.07)] hover:shadow-xl transition-all duration-500">
       <div class="flex gap-6">
         <a href="/" class="text-sm font-medium transition-colors {$page.url.pathname === '/' ? 'text-black dark:text-white drop-shadow-md' : 'text-gray-500 dark:text-gray-400 hover:text-black dark:hover:text-white'}">Home</a>
-        <a href="/cv" class="text-sm font-medium transition-colors {$page.url.pathname === '/cv' ? 'text-black dark:text-white drop-shadow-md' : 'text-gray-500 dark:text-gray-400 hover:text-black dark:hover:text-white'}">CV</a>
-        <a href="/academia" class="text-sm font-medium transition-colors {$page.url.pathname === '/academia' ? 'text-black dark:text-white drop-shadow-md' : 'text-gray-500 dark:text-gray-400 hover:text-black dark:hover:text-white'}">Academia</a>
-        <a href="/projects" class="text-sm font-medium transition-colors {$page.url.pathname === '/projects' ? 'text-black dark:text-white drop-shadow-md' : 'text-gray-500 dark:text-gray-400 hover:text-black dark:hover:text-white'}">Projects</a>
-        <a href="/blog" class="text-sm font-medium transition-colors {$page.url.pathname === '/blog' ? 'text-black dark:text-white drop-shadow-md' : 'text-gray-500 dark:text-gray-400 hover:text-black dark:hover:text-white'}">Blog</a>
+        <a href="/cv" class="text-sm font-medium transition-colors {normalizedPath === '/cv' ? 'text-black dark:text-white drop-shadow-md' : 'text-gray-500 dark:text-gray-400 hover:text-black dark:hover:text-white'}">CV</a>
+        <a href="/academia" class="text-sm font-medium transition-colors {normalizedPath === '/academia' ? 'text-black dark:text-white drop-shadow-md' : 'text-gray-500 dark:text-gray-400 hover:text-black dark:hover:text-white'}">Academia</a>
+        <a href="/projects" class="text-sm font-medium transition-colors {normalizedPath === '/projects' ? 'text-black dark:text-white drop-shadow-md' : 'text-gray-500 dark:text-gray-400 hover:text-black dark:hover:text-white'}">Projects</a>
+        <a href="/blog" class="text-sm font-medium transition-colors {normalizedPath === '/blog' ? 'text-black dark:text-white drop-shadow-md' : 'text-gray-500 dark:text-gray-400 hover:text-black dark:hover:text-white'}">Blog</a>
       </div>
     </div>
   </div>
@@ -54,6 +72,7 @@
 
   <footer class="py-10 text-center text-sm">
     <p class="text-md font-light text-gray-400 dark:text-gray-600">
-			&copy; {new Date().getFullYear()} Niccolò Barbini. All rights reserved.</p>
+      &copy; {new Date().getFullYear()} Niccolò Barbini. All rights reserved.
+    </p>
   </footer>
 </div>

--- a/src/routes/academia/+page.svelte
+++ b/src/routes/academia/+page.svelte
@@ -3,7 +3,6 @@
 </script>
 
 <svelte:head>
-	<title>Academic CV</title>
 	<meta name="description" content="Academic background and research." />
 </svelte:head>
 


### PR DESCRIPTION
This PR fixes a bug where the document title remained stuck as "Academic CV" after navigating away from the Academia section.

close #17 