### PR TITLE
feat: Disable automatic dark mode from system preferences

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -6,22 +6,20 @@
 
 html {
   scroll-behavior: smooth;
+  color-scheme: light;
 }
 
 body {
   font-family: 'Inter', sans-serif;
-  @apply bg-gray-50 text-gray-900 antialiased selection:bg-blue-500/30 selection:text-blue-900 dark:selection:text-blue-200;
+  @apply bg-gray-50 text-gray-900 antialiased selection:bg-blue-500/30 selection:text-blue-900;
   overflow-x: hidden;
-}
-
-:global(.dark) body {
-  @apply bg-[#050505] text-gray-100; /* Darker, richer black than standard */
 }
 
 /* Hide scrollbar for cleaner look on bento boxes if they overflow */
 .no-scrollbar::-webkit-scrollbar {
   display: none;
 }
+
 .no-scrollbar {
   -ms-overflow-style: none;
   scrollbar-width: none;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,9 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
+
   content: ['./src/**/*.{html,js,svelte,ts,md}'],
+
   theme: {
     extend: {
       animation: {
@@ -29,12 +32,13 @@ export default {
       }
     },
   },
+
   plugins: [
     require('@tailwindcss/typography'),
     require("daisyui")
   ],
+
   daisyui: {
-    themes: ["lofi", "black"], 
-    darkTheme: "black",
+    themes: ["lofi"],
   },
 }


### PR DESCRIPTION
### Disable automatic dark mode from system preferences

This PR prevents the website from automatically switching to dark mode when the user’s device or browser is set to dark mode.
The site now consistently uses the light theme unless dark mode is explicitly enabled through a class-based setup in the future.

**Changes:**

- Configured Tailwind dark mode to use class-based toggling instead of system preferences.
- Removed DaisyUI’s automatic dark theme configuration.
- Removed the black DaisyUI dark theme.
- Removed dark-mode body styling from app.css.
- Removed dark: selection styling.
- Added color-scheme: light to keep browser-rendered UI elements in light mode.


**Notes**
Dark mode can still be reintroduced later using explicit class-based toggling if needed.